### PR TITLE
Bumping version to 2.0.4-SNAPSHOT and fixing license URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.serpapi</groupId>
     <artifactId>serpapi4j</artifactId>
-    <version>2.0.3-SNAPSHOT</version>
+    <version>2.0.4-SNAPSHOT</version>
     <name>serpapi4j</name>
     <description>A java library to use SerpApi</description>
 
@@ -15,7 +15,7 @@
                 MIT License
             </name>
             <url>
-                http://www.fsf.org/licensing/licenses/lgpl.txt
+                https://opensource.org/licenses/MIT
             </url>
         </license>
     </licenses>


### PR DESCRIPTION
There is already a 2.0.3 tag so to be able to branch off properly
from the origin's tags and releases bumping version to 2.0.4 to
be able to make a clean branch point, to avoid version 2.0.3 to
mean to separate things.

Also fixing the license URL to be the correct one for the MIT
license.